### PR TITLE
Chunk death fixes

### DIFF
--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -597,7 +597,7 @@
         "chanceToCreate": 1,
         "mass": 0.08,
         "displayScene": "",
-        "corpseChunkScene": "res://assets/models/organelles/Cytoplasm.tscn",
+        "corpseChunkScene": "",
         "name": "CYTOPLASM",
         "productionColour": "#1db7c5",
         "consumptionColour": "#c51d38",

--- a/simulation_parameters/microbe_stage/organelles.json
+++ b/simulation_parameters/microbe_stage/organelles.json
@@ -124,7 +124,7 @@
         "chanceToCreate": 0,
         "mass": 0.1,
         "displayScene": "",
-        "corpseChunkScene": "res://assets/models/organelles/Cytoplasm.tscn",
+        "corpseChunkScene": "",
         "name": "PROTOPLASM",
         "editorButtonGroup": "Hidden",
         "editorButtonOrder": 5,

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -500,8 +500,7 @@ public partial class Microbe
             // Amount of compound in one chunk
             float amount = HexCount / Constants.CORPSE_CHUNK_AMOUNT_DIVISOR;
 
-            var positionAdded = new Vector3(random.Next(-2.0f, 2.0f), 0,
-                random.Next(-2.0f, 2.0f));
+            var positionOffset = new Vector3((organelle.Position.R / -2.0f) * Mathf.Cos(Rotation.y), 0.0f, (organelle.Position.R / -2.0f) * Mathf.Sin(Rotation.y));
 
             var chunkType = new ChunkConfiguration
             {
@@ -561,7 +560,7 @@ public partial class Microbe
             chunkType.Meshes.Add(sceneToUse);
 
             // Finally spawn a chunk with the settings
-            var chunk = SpawnHelpers.SpawnChunk(chunkType, Translation + positionAdded, GetStageAsParent(),
+            var chunk = SpawnHelpers.SpawnChunk(chunkType, Translation + positionOffset, GetStageAsParent(),
                 chunkScene, random);
 
             // Add to the spawn system to make these chunks limit possible number of entities

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -516,23 +516,6 @@ public partial class Microbe
                 Compounds = new Dictionary<Compound, ChunkConfiguration.ChunkCompound>(),
             };
 
-            // They were added in order already so looping through this other thing is fine
-            foreach (var entry in compoundsToRelease)
-            {
-                var compoundAmount = (entry.Value / random.Next(amount / 3.0f, amount)) *
-                        Constants.CORPSE_COMPOUND_COMPENSATION;
-
-                var compoundValue = new ChunkConfiguration.ChunkCompound
-                {
-                    // Randomize compound amount a bit so things "rot away"
-                    Amount = compoundAmount,
-                };
-
-                chunkType.Compounds[entry.Key] = compoundValue;
-
-                compoundsToRelease[entry.Key] = entry.Value - compoundAmount;
-            }
-
             chunkType.Meshes = new List<ChunkConfiguration.ChunkScene>();
 
             var sceneToUse = new ChunkConfiguration.ChunkScene();
@@ -554,10 +537,26 @@ public partial class Microbe
                 continue;
             }
 
-             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            // ReSharper disable once HeuristicUnreachableCode
-            if (sceneToUse == null)
-                throw new Exception("sceneToUse is null");
+            // They were added in order already so looping through this other thing is fine
+            foreach (var entry in compoundsToRelease.Keys.ToList())
+            {
+                if (compoundsToRelease[entry] <= 0.0f)
+                {
+                    continue;
+                }
+
+                var compoundAmount = compoundsToRelease[entry] * random.Next(amount / 3.0f, amount / 2.0f);
+
+                var compoundValue = new ChunkConfiguration.ChunkCompound
+                {
+                    // Randomize compound amount a bit so things "rot away"
+                    Amount = compoundAmount,
+                };
+
+                chunkType.Compounds[entry] = compoundValue;
+
+                compoundsToRelease[entry] = compoundsToRelease[entry] - compoundAmount;
+            }
 
             chunkType.Meshes.Add(sceneToUse);
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -569,7 +569,7 @@ public partial class Microbe
 
         foreach (var compound in compoundsToRelease)
         {
-            SpawnHelpers.SpawnCloud(cloudSystem, GlobalTransform.origin, compound.Key, compound.Value);
+            cloudSystem.AddCloud(compound.Key, compound.Value / Constants.ABSORPTION_RATIO, Translation);
         }
 
         // Subtract population

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -487,7 +487,7 @@ public partial class Microbe
                 compoundsToRelease.TryGetValue(entry.Key, out var existing);
 
                 compoundsToRelease[entry.Key] = existing + (entry.Value *
-                    Constants.COMPOUND_MAKEUP_RELEASE_PERCENTAGE * 20.0f);
+                    Constants.COMPOUND_MAKEUP_RELEASE_PERCENTAGE * 5.0f);
             }
         }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -487,7 +487,7 @@ public partial class Microbe
                 compoundsToRelease.TryGetValue(entry.Key, out var existing);
 
                 compoundsToRelease[entry.Key] = existing + (entry.Value *
-                    Constants.COMPOUND_MAKEUP_RELEASE_PERCENTAGE);
+                    Constants.COMPOUND_MAKEUP_RELEASE_PERCENTAGE * 20.0f);
             }
         }
 

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -504,7 +504,7 @@ public partial class Microbe
 
             var chunkType = new ChunkConfiguration
             {
-                ChunkScale = 1.0f,
+                ChunkScale = CellTypeProperties.IsBacteria ? 0.5f : 1.0f,
                 Dissolves = true,
                 Mass = 1.0f,
                 Radius = 1.0f,

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -567,6 +567,11 @@ public partial class Microbe
             ModLoader.ModInterface.TriggerOnChunkSpawned(chunk, false);
         }
 
+        foreach (var compound in compoundsToRelease)
+        {
+            SpawnHelpers.SpawnCloud(cloudSystem, GlobalTransform.origin, compound.Key, compound.Value);
+        }
+
         // Subtract population
         if (!IsPlayerMicrobe && !Species.PlayerSpecies)
         {

--- a/src/microbe_stage/Microbe.Contact.cs
+++ b/src/microbe_stage/Microbe.Contact.cs
@@ -519,14 +519,18 @@ public partial class Microbe
             // They were added in order already so looping through this other thing is fine
             foreach (var entry in compoundsToRelease)
             {
+                var compoundAmount = (entry.Value / random.Next(amount / 3.0f, amount)) *
+                        Constants.CORPSE_COMPOUND_COMPENSATION;
+
                 var compoundValue = new ChunkConfiguration.ChunkCompound
                 {
                     // Randomize compound amount a bit so things "rot away"
-                    Amount = (entry.Value / random.Next(amount / 3.0f, amount)) *
-                        Constants.CORPSE_COMPOUND_COMPENSATION,
+                    Amount = compoundAmount,
                 };
 
                 chunkType.Compounds[entry.Key] = compoundValue;
+
+                compoundsToRelease[entry.Key] = entry.Value - compoundAmount;
             }
 
             chunkType.Meshes = new List<ChunkConfiguration.ChunkScene>();

--- a/src/microbe_stage/Microbe.Interior.cs
+++ b/src/microbe_stage/Microbe.Interior.cs
@@ -490,6 +490,11 @@ public partial class Microbe
 
     private void HandleCompoundAbsorbing(float delta)
     {
+        if (Dead)
+        {
+            return;
+        }
+
         // max here buffs compound absorbing for the smallest cells
         var grabRadius = Mathf.Max(Radius, 3.0f);
 

--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -342,12 +342,6 @@ public class OrganelleDefinition : IRegistryType
             throw new InvalidRegistryDataException(name, GetType().Name, "Hexes is empty");
         }
 
-        if (string.IsNullOrEmpty(DisplayScene) && string.IsNullOrEmpty(CorpseChunkScene))
-        {
-            throw new InvalidRegistryDataException(name, GetType().Name,
-                "Both DisplayScene and CorpseChunkScene are null");
-        }
-
         // Check for duplicate position hexes
         for (int i = 0; i < Hexes.Count; ++i)
         {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Updates chunks spawned on death to be accurate to the size and composition of the microbe that spawned them.

**Related Issues (if any)**


