### PR TITLE
Add print species button

### DIFF
--- a/locale/en.po
+++ b/locale/en.po
@@ -3124,6 +3124,10 @@ msgstr "Duplicate Player"
 msgid "SPAWN_ENEMY"
 msgstr "Spawn Enemy"
 
+#: ../src/microbe_stage/MicrobeCheatMenu.tscn:94
+msgid "PRINT_SPECIES"
+msgstr "Spawn All Species"
+
 #: ../src/microbe_stage/MicrobeHUD.cs:560
 msgid "SIGNAL_COMMAND_NONE"
 msgstr "No Command"

--- a/src/engine/CheatManager.cs
+++ b/src/engine/CheatManager.cs
@@ -23,6 +23,11 @@ public static class CheatManager
     public static event EventHandler<EventArgs>? OnSpawnEnemyCheatUsed;
 
     /// <summary>
+    ///   Fired whenever the user uses the "Print Species" cheat
+    /// </summary>
+    public static event EventHandler<EventArgs>? OnPrintSpeciesCheatUsed;
+
+    /// <summary>
     ///   You automatically have 100% of all compounds
     /// </summary>
     public static bool InfiniteCompounds { get; set; }
@@ -62,6 +67,14 @@ public static class CheatManager
     public static void SpawnEnemy()
     {
         OnSpawnEnemyCheatUsed?.Invoke(null, EventArgs.Empty);
+    }
+
+    /// <summary>
+    ///   Spawns one of every species in the patch
+    /// </summary>
+    public static void PrintSpecies()
+    {
+        OnPrintSpeciesCheatUsed?.Invoke(null, EventArgs.Empty);
     }
 
     public static void DisableAllCheats()

--- a/src/microbe_stage/MicrobeCheatMenu.cs
+++ b/src/microbe_stage/MicrobeCheatMenu.cs
@@ -23,12 +23,16 @@ public class MicrobeCheatMenu : CheatMenu
     [Export]
     public NodePath SpawnEnemyPath = null!;
 
+    [Export]
+    public NodePath PrintSpeciesPath = null!;
+
     private CustomCheckBox infiniteCompounds = null!;
     private CustomCheckBox godMode = null!;
     private CustomCheckBox disableAI = null!;
     private Slider speed = null!;
     private Button playerDivide = null!;
     private Button spawnEnemy = null!;
+    private Button printSpecies = null!;
 
     public override void _Ready()
     {
@@ -38,9 +42,11 @@ public class MicrobeCheatMenu : CheatMenu
         speed = GetNode<Slider>(SpeedSliderPath);
         playerDivide = GetNode<Button>(PlayerDividePath);
         spawnEnemy = GetNode<Button>(SpawnEnemyPath);
+        printSpecies = GetNode<Button>(PrintSpeciesPath);
 
         playerDivide.Connect("pressed", this, nameof(OnPlayerDivideClicked));
         spawnEnemy.Connect("pressed", this, nameof(OnSpawnEnemyClicked));
+        printSpecies.Connect("pressed", this, nameof(OnPrintSpeciesClicked));
         base._Ready();
     }
 
@@ -60,5 +66,10 @@ public class MicrobeCheatMenu : CheatMenu
     private void OnSpawnEnemyClicked()
     {
         CheatManager.SpawnEnemy();
+    }
+
+    private void OnPrintSpeciesClicked()
+    {
+        CheatManager.PrintSpecies();
     }
 }

--- a/src/microbe_stage/MicrobeCheatMenu.tscn
+++ b/src/microbe_stage/MicrobeCheatMenu.tscn
@@ -20,6 +20,7 @@ DisableAIPath = NodePath("VBoxContainer/DisableAI")
 SpeedSliderPath = NodePath("VBoxContainer/Speed/SpeedSlider")
 PlayerDividePath = NodePath("VBoxContainer/PlayerDuplicate")
 SpawnEnemyPath = NodePath("VBoxContainer/SpawnEnemy")
+PrintSpeciesPath = NodePath("VBoxContainer/PrintSpecies")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 177.0
@@ -92,6 +93,16 @@ margin_right = 177.0
 margin_bottom = 142.0
 custom_fonts/font = ExtResource( 3 )
 text = "SPAWN_ENEMY"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PrintSpecies" type="Button" parent="VBoxContainer"]
+margin_top = 145.0
+margin_right = 177.0
+margin_bottom = 182.0
+custom_fonts/font = ExtResource( 3 )
+text = "PRINT_SPECIES"
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -240,12 +240,14 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
     {
         base._EnterTree();
         CheatManager.OnSpawnEnemyCheatUsed += OnSpawnEnemyCheatUsed;
+        CheatManager.OnPrintSpeciesCheatUsed += OnPrintSpeciesCheatUsed;
     }
 
     public override void _ExitTree()
     {
         base._ExitTree();
         CheatManager.OnSpawnEnemyCheatUsed -= OnSpawnEnemyCheatUsed;
+        CheatManager.OnPrintSpeciesCheatUsed -= OnPrintSpeciesCheatUsed;
     }
 
     public override void _Notification(int what)
@@ -811,6 +813,11 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
 
         // Make the cell despawn like normal
         SpawnSystem.AddEntityToTrack(copyEntity);
+    }
+
+    private void OnPrintSpeciesCheatUsed(object sender, EventArgs e)
+    {
+        DebugPrintSpecies();
     }
 
     [DeserializedCallbackAllowed]


### PR DESCRIPTION
**Brief Description of What This PR Does**

In lieu of proper auto-evo exploration, this adds a cheat that just displays one of each species currently in the patch, with more populous species being placed lower.

**Related Issues (if any)**


