### PR TITLE
Late engulf button

### DIFF
--- a/locale/en.po
+++ b/locale/en.po
@@ -4654,7 +4654,7 @@ msgstr "The bubble took so much, it split in half.\nBut neither one popped."
 
 #: ../src/microbe_stage/MicrobeStage.cs:506
 msgid "ENGULF_MESSAGE"
-msgstr "The larger bubbles could even\nconsume the smaller ones."
+msgstr "The larger bubbles could even\nconsume other, smaller species."
 
 #: ../src/microbe_stage/MicrobeStage.cs:930
 msgid "EPIPELAGIC_INTRO_MESSAGE"

--- a/locale/en.po
+++ b/locale/en.po
@@ -4652,6 +4652,10 @@ msgstr "When a bubble ran out of energy,\nphysics took the molecules back."
 msgid "EDITOR_BUTTON_MESSAGE"
 msgstr "The bubble took so much, it split in half.\nBut neither one popped."
 
+#: ../src/microbe_stage/MicrobeStage.cs:506
+msgid "ENGULF_MESSAGE"
+msgstr "The larger bubbles could even\nconsume the smaller ones."
+
 #: ../src/microbe_stage/MicrobeStage.cs:930
 msgid "EPIPELAGIC_INTRO_MESSAGE"
 msgstr "Some come to the open sea, near the sun.\nBut no glucose floated here."

--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -1283,7 +1283,7 @@ public class MicrobeHUD : Control
 
     private void UpdateAbilitiesHotBar(Microbe player)
     {
-        engulfHotkey.Visible = !player.CellTypeProperties.MembraneType.CellWall;
+        engulfHotkey.Visible = !player.CellTypeProperties.MembraneType.CellWall && player.EngulfSize >= 2;
         bindingModeHotkey.Visible = player.CanBind;
         fireToxinHotkey.Visible = player.AgentVacuoleCount > 0;
         unbindAllHotkey.Visible = player.CanUnbind;

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -492,12 +492,18 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
                 guidanceLine.Visible = false;
             }
 
+            // See if any states are active for displaying intro messages
             if (!TutorialState.EditorWelcome.TrustPlayer
                 && Player.Compounds.GetCompoundAmount(SimulationParameters.Instance.GetCompound("atp")) <= 0.1f
                 && !TutorialState.HaveShownATPMessage)
             {
                 HUD.DisplayMessageIfIntro("STARVATION_MESSAGE");
                 TutorialState.HaveShownATPMessage = true;
+            }
+            else if (!TutorialState.HasEngulfed)
+            {
+                HUD.DisplayMessageIfIntro("ENGULF_MESSAGE");
+                TutorialState.HasEngulfed = true;
             }
         }
         else

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -500,7 +500,7 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
                 HUD.DisplayMessageIfIntro("STARVATION_MESSAGE");
                 TutorialState.HaveShownATPMessage = true;
             }
-            else if (!TutorialState.HasEngulfed)
+            else if (!TutorialState.HasEngulfed && Player.State == Microbe.MicrobeState.Engulf)
             {
                 HUD.DisplayMessageIfIntro("ENGULF_MESSAGE");
                 TutorialState.HasEngulfed = true;

--- a/src/tutorial/TutorialState.cs
+++ b/src/tutorial/TutorialState.cs
@@ -75,6 +75,9 @@ public class TutorialState : ITutorialInput
     [JsonProperty]
     public bool HasBeenToEpipelagic;
 
+    [JsonProperty]
+    public bool HasEngulfed;
+
     /// <summary>
     ///   True if any of the tutorials are active that want to pause the game
     /// </summary>


### PR DESCRIPTION
**Brief Description of What This PR Does**

Don't show the engulf button if you wouldn't be big enough to actually engulf anything in the game, and display an intro message the first time you do.

**Related Issues (if any)**


