### PR TITLE
only show engulf hotkey if the player has been through the editor

### DIFF
--- a/src/microbe_stage/MicrobeHUD.cs
+++ b/src/microbe_stage/MicrobeHUD.cs
@@ -1283,7 +1283,7 @@ public class MicrobeHUD : Control
 
     private void UpdateAbilitiesHotBar(Microbe player)
     {
-        engulfHotkey.Visible = !player.CellTypeProperties.MembraneType.CellWall && player.EngulfSize >= 2;
+        engulfHotkey.Visible = !player.CellTypeProperties.MembraneType.CellWall && (!Settings.Instance.PlayMicrobeIntroVideo || (stage.TutorialState.HaveBeenToEditor && player.EngulfSize >= 2));
         bindingModeHotkey.Visible = player.CanBind;
         fireToxinHotkey.Visible = player.AgentVacuoleCount > 0;
         unbindAllHotkey.Visible = player.CanUnbind;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Don't show the engulf hotkey until after the player went into the editor

**Related Issues (if any)**


