### PR TITLE
saves now use the menu theme, and not a later stage concept art

### DIFF
--- a/simulation_parameters/common/gallery.json
+++ b/simulation_parameters/common/gallery.json
@@ -116,9 +116,18 @@
                         "ResourcePath": "res://assets/concept_art/tribe-gang.jpg"
                     }
                 ]
+            },
+            "Default": {
+                "Name": "DEFAULT",
+                "Assets": [
+                    {
+                        "Title": "Menu Background 1",
+                        "Artist": "kertit",
+                        "ResourcePath": "res://assets/textures/gui/BG_Menu01.png"
+                    }
+                ]
             }
-        }
-    },
+        },
     "Models": {
         "Name": "MODELS",
         "AssetCategories": {

--- a/src/engine/LoadingScreen.cs
+++ b/src/engine/LoadingScreen.cs
@@ -180,7 +180,7 @@ public class LoadingScreen : Control
         var gameStateName = CurrentlyLoadingGameState.ToString();
         var gallery = SimulationParameters.Instance.GetGallery("ConceptArt");
 
-        var category = gallery.AssetCategories.ContainsKey(gameStateName) ? gameStateName : "General";
+        var category = gallery.AssetCategories.ContainsKey(gameStateName) ? gameStateName : "Default";
         var artwork = gallery.AssetCategories[category].Assets.Random(random);
 
         artworkRect.Texture = GD.Load<Texture>(artwork.ResourcePath);


### PR DESCRIPTION
**Brief Description of What This PR Does**

I feel like showing aware stage stuff when loading a game it breaks immersion

**Related Issues (if any)**


