### PR TITLE
Anti spawnrush

### DIFF
--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -77,6 +77,9 @@ public class MicrobeAI
     [JsonProperty]
     private bool hasBeenNearPlayer;
 
+    [JsonProperty]
+    private Vector3 playerPositionAtSpawn;
+
     public MicrobeAI(Microbe microbe)
     {
         this.microbe = microbe ?? throw new ArgumentException("no microbe given", nameof(microbe));
@@ -238,13 +241,19 @@ public class MicrobeAI
             var player = data.AllMicrobes.Where(otherMicrobe => otherMicrobe.IsPlayerMicrobe).FirstOrDefault();
             if (player != null)
             {
-                if (DistanceFromMe(player.GlobalTransform.origin) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
+                if (playerPositionAtSpawn == null)
                 {
-                    MoveToLocation(player.GlobalTransform.origin);
-                    return;
+                    playerPositionAtSpawn = player.GlobalTransform.origin;
                 }
 
-                hasBeenNearPlayer = true;
+                if (DistanceFromMe(playerPositionAtSpawn) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
+                {
+                    MoveToLocation(playerPositionAtSpawn);
+                }
+                else
+                {
+                    hasBeenNearPlayer = true;
+                }
             }
         }
 

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -249,6 +249,7 @@ public class MicrobeAI
                 if (DistanceFromMe(playerPositionAtSpawn) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
                 {
                     MoveToLocation(playerPositionAtSpawn);
+                    return;
                 }
                 else
                 {


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the AI start by moving towards the player's location at time of spawn, rather than constantly chasing the player.

**Related Issues (if any)**


