### PR TITLE
Speed based spawn

### DIFF
--- a/src/early_multicellular_stage/CellTemplate.cs
+++ b/src/early_multicellular_stage/CellTemplate.cs
@@ -58,9 +58,9 @@ public class CellTemplate : IPositionedCell, ICloneable, IActionHex
         CellType.RepositionToOrigin();
     }
 
-    public void CalculateRotationSpeed()
+    public void CalculateSpeedValues()
     {
-        CellType.CalculateRotationSpeed();
+        CellType.CalculateSpeedValues();
     }
 
     public void UpdateNameIfValid(string newName)

--- a/src/early_multicellular_stage/CellType.cs
+++ b/src/early_multicellular_stage/CellType.cs
@@ -48,6 +48,7 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
     public float MembraneRigidity { get; set; }
     public Color Colour { get; set; }
     public bool IsBacteria { get; set; }
+    public float BaseSpeed { get; set; }
     public float BaseRotationSpeed { get; set; }
 
     [JsonIgnore]
@@ -61,8 +62,9 @@ public class CellType : ICellProperties, IPhotographable, ICloneable
         Organelles.RepositionToOrigin();
     }
 
-    public void CalculateRotationSpeed()
+    public void CalculateSpeedValues()
     {
+        BaseSpeed = MicrobeInternalCalculations.CalculateSpeed(Organelles, MembraneType, MembraneRigidity);
         BaseRotationSpeed = MicrobeInternalCalculations.CalculateRotationSpeed(Organelles);
     }
 

--- a/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
+++ b/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
@@ -22,6 +22,8 @@ public class EarlyMulticellularSpecies : Species
     [JsonProperty]
     public List<CellType> CellTypes { get; private set; } = new();
 
+    public override float BaseSpeed => throw new System.NotImplementedException();
+
     /// <summary>
     ///   All organelles in all of the species' placed cells (there can be a lot of duplicates in this list)
     /// </summary>

--- a/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
+++ b/src/early_multicellular_stage/EarlyMulticellularSpecies.cs
@@ -22,7 +22,7 @@ public class EarlyMulticellularSpecies : Species
     [JsonProperty]
     public List<CellType> CellTypes { get; private set; } = new();
 
-    public override float BaseSpeed => throw new System.NotImplementedException();
+    public override float BaseSpeed => CellTypes.First().BaseSpeed;
 
     /// <summary>
     ///   All organelles in all of the species' placed cells (there can be a lot of duplicates in this list)
@@ -41,7 +41,7 @@ public class EarlyMulticellularSpecies : Species
         // Make certain these are all up to date
         foreach (var cellType in CellTypes)
         {
-            cellType.CalculateRotationSpeed();
+            cellType.CalculateSpeedValues();
         }
     }
 

--- a/src/general/Species.cs
+++ b/src/general/Species.cs
@@ -46,6 +46,8 @@ public abstract class Species : ICloneable
     [JsonProperty]
     public BehaviourDictionary Behaviour { get; set; } = new();
 
+    public abstract float BaseSpeed { get; }
+
     /// <summary>
     ///   This is the global population (the sum of population in all patches)
     /// </summary>

--- a/src/microbe_stage/ICellProperties.cs
+++ b/src/microbe_stage/ICellProperties.cs
@@ -18,7 +18,7 @@ public interface ICellProperties
     ///   Calculates the rotation speed of a cell. This is and <see cref="RepositionToOrigin"/> are separately here
     ///   to allow the cell editor to skip some stuff <see cref="Species.OnEdited"/> does.
     /// </summary>
-    public void CalculateRotationSpeed();
+    public void CalculateSpeedValues();
 
     public void RepositionToOrigin();
     public void UpdateNameIfValid(string newName);

--- a/src/microbe_stage/MicrobeAI.cs
+++ b/src/microbe_stage/MicrobeAI.cs
@@ -78,7 +78,7 @@ public class MicrobeAI
     private bool hasBeenNearPlayer;
 
     [JsonProperty]
-    private Vector3 playerPositionAtSpawn;
+    private Vector3? playerPositionAtSpawn = null;
 
     public MicrobeAI(Microbe microbe)
     {
@@ -238,7 +238,7 @@ public class MicrobeAI
         // If I'm very far from the player, and I have not been near the player yet, get on stage
         if (!hasBeenNearPlayer)
         {
-            var player = data.AllMicrobes.Where(otherMicrobe => otherMicrobe.IsPlayerMicrobe).FirstOrDefault();
+            var player = data.AllMicrobes.Where(otherMicrobe => !otherMicrobe.Dead && otherMicrobe.IsPlayerMicrobe).FirstOrDefault();
             if (player != null)
             {
                 if (playerPositionAtSpawn == null)
@@ -246,9 +246,9 @@ public class MicrobeAI
                     playerPositionAtSpawn = player.GlobalTransform.origin;
                 }
 
-                if (DistanceFromMe(playerPositionAtSpawn) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
+                if (DistanceFromMe((Vector3)playerPositionAtSpawn) > Math.Pow(Constants.SPAWN_SECTOR_SIZE, 2) * 0.75f)
                 {
-                    MoveToLocation(playerPositionAtSpawn);
+                    MoveToLocation((Vector3)playerPositionAtSpawn);
                     return;
                 }
                 else

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -75,7 +75,7 @@ public class MicrobeSpecies : Species, ICellProperties
     {
         RepositionToOrigin();
         UpdateInitialCompounds();
-        CalculateRotationSpeed();
+        CalculateSpeedValues();
     }
 
     public override void RepositionToOrigin()
@@ -83,7 +83,7 @@ public class MicrobeSpecies : Species, ICellProperties
         Organelles.RepositionToOrigin();
     }
 
-    public void CalculateRotationSpeed()
+    public void CalculateSpeedValues()
     {
         BaseRotationSpeed = MicrobeInternalCalculations.CalculateRotationSpeed(Organelles);
     }

--- a/src/microbe_stage/MicrobeSpecies.cs
+++ b/src/microbe_stage/MicrobeSpecies.cs
@@ -57,7 +57,7 @@ public class MicrobeSpecies : Species, ICellProperties
     // Even though these properties say "base" it includes the specialized organelle factors. Base refers here to
     // the fact that these are the values when a cell is freshly spawned and has no reproduction progress.
     [JsonIgnore]
-    public float BaseSpeed => MicrobeInternalCalculations.CalculateSpeed(Organelles, MembraneType, MembraneRigidity);
+    public override float BaseSpeed => MicrobeInternalCalculations.CalculateSpeed(Organelles, MembraneType, MembraneRigidity);
 
     [JsonProperty]
     public float BaseRotationSpeed { get; set; } = Constants.CELL_BASE_ROTATION;

--- a/src/microbe_stage/SpawnSystem.cs
+++ b/src/microbe_stage/SpawnSystem.cs
@@ -323,13 +323,12 @@ public class SpawnSystem
         var spawns = 0;
         foreach (var spawnType in spawnTypes)
         {
-            if (spawnType is MicrobeSpawner)
+            if (spawnType is MicrobeSpawner
+                && ((MicrobeSpawner)spawnType).Species.BaseSpeed > MathUtils.EPSILON)
             {
-                
                     spawns += SpawnWithSpawner(spawnType,
                         playerLocation + new Vector3(Mathf.Cos(angle) * Constants.SPAWN_SECTOR_SIZE * 2, 0,
                             Mathf.Sin(angle) * Constants.SPAWN_SECTOR_SIZE * 2));
-                
             }
         }
 
@@ -423,43 +422,6 @@ public class SpawnSystem
         entity.DespawnRadiusSquared = (int)(radius * radius);
 
         entity.EntityNode.AddToGroup(Constants.SPAWNED_GROUP);
-    }
-
-    /// <summary>
-    ///   Returns a random rotation (in radians)
-    ///   If weighted, it is more likely to return a rotation closer to the target rotation than not
-    /// </summary>
-    private float ComputeRandomRadianRotation(float targetRotation, bool weighted)
-    {
-        float rotation1 = random.NextFloat() * 2 * Mathf.Pi;
-
-        if (weighted)
-        {
-            targetRotation = WithNegativesToNormalRadians(targetRotation);
-            float rotation2 = random.NextFloat() * 2 * Mathf.Pi;
-
-            if (DistanceBetweenRadians(rotation2, targetRotation) < DistanceBetweenRadians(rotation1, targetRotation))
-                return NormalToWithNegativesRadians(rotation2);
-        }
-
-        return NormalToWithNegativesRadians(rotation1);
-    }
-
-    // TODO Could use to be moved to mathUtils?
-    private float NormalToWithNegativesRadians(float radian)
-    {
-        return radian <= Math.PI ? radian : radian - (float)(2 * Math.PI);
-    }
-
-    private float WithNegativesToNormalRadians(float radian)
-    {
-        return radian >= 0 ? radian : (float)(2 * Math.PI) - radian;
-    }
-
-    private float DistanceBetweenRadians(float p1, float p2)
-    {
-        float distance = Math.Abs(p1 - p2);
-        return distance <= Math.PI ? distance : (float)(2 * Math.PI) - distance;
     }
 
     private class QueuedSpawn

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -249,7 +249,7 @@ public class MicrobeSpawner : Spawner
         random = new Random();
     }
 
-    public MicrobeSpecies Species { get; }
+    public Species Species { get; }
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
     {

--- a/src/microbe_stage/Spawners.cs
+++ b/src/microbe_stage/Spawners.cs
@@ -249,7 +249,7 @@ public class MicrobeSpawner : Spawner
         random = new Random();
     }
 
-    public Species Species { get; }
+    public MicrobeSpecies Species { get; }
 
     public override IEnumerable<ISpawned>? Spawn(Node worldNode, Vector3 location)
     {

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -674,7 +674,7 @@ public partial class CellEditorComponent :
         }
 
         editedProperties.RepositionToOrigin();
-        editedProperties.CalculateRotationSpeed();
+        editedProperties.CalculateSpeedValues();
 
         // Update bacteria status
         editedProperties.IsBacteria = !HasNucleus;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Don't spawn species around the player if they couldn't have moved. Does NOT account for species that are sessile by choice.

**Related Issues (if any)**


