### PR TITLE
Display at rest compound balances

### DIFF
--- a/src/microbe_stage/CompoundBalance.cs
+++ b/src/microbe_stage/CompoundBalance.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Godot;
 
 /// <summary>
 ///   Balance of a given compound. Lists the organelles that contribute to the balance

--- a/src/microbe_stage/CompoundBalance.cs
+++ b/src/microbe_stage/CompoundBalance.cs
@@ -14,6 +14,12 @@ public class CompoundBalance
     /// </summary>
     public float Balance;
 
+    public CompoundBalance(float consumption, float production)
+    {
+        AddConsumption("all", consumption);
+        AddProduction("all", production);
+    }
+
     public void AddConsumption(string organelleName, float amount)
     {
         Consumption.TryGetValue(organelleName, out var existing);

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -404,11 +404,13 @@ public static class MicrobeInternalCalculations
         {
             foreach (var input in process.Process.Inputs)
             {
+                MakeSureResultExists(input.Key);
                 result[input.Key].AddConsumption("all", input.Value * process.Rate);
             }
 
             foreach (var output in process.Process.Outputs)
             {
+                MakeSureResultExists(output.Key);
                 result[output.Key].AddProduction("all", output.Value * process.Rate);
             }
         }

--- a/src/microbe_stage/MicrobeInternalCalculations.cs
+++ b/src/microbe_stage/MicrobeInternalCalculations.cs
@@ -380,7 +380,7 @@ public static class MicrobeInternalCalculations
     ///   Computes the compound balances for given organelle list in a patch
     /// </summary>
     public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalance(
-        IEnumerable<OrganelleDefinition> organelles, MembraneType membrane, BiomeConditions biome)
+        IEnumerable<OrganelleDefinition> organelles, MembraneType membrane, BiomeConditions biome, bool moving)
     {
         var result = new Dictionary<Compound, CompoundBalance>();
 
@@ -393,13 +393,14 @@ public static class MicrobeInternalCalculations
         }
 
         var compoundBag = new CompoundBag(organelles.Sum(x => x.Storage()));
+        var totalCost = moving ? MovementCost(organelles, membrane) + OsmoregulationCost(organelles, membrane) : OsmoregulationCost(organelles, membrane);
 
         compoundBag.AddCompound(Compound.ByName("glucose"), compoundBag.Capacity / 2);
         compoundBag.AddCompound(Compound.ByName("iron"), compoundBag.Capacity / 2);
         compoundBag.AddCompound(Compound.ByName("hydrogensulfide"), compoundBag.Capacity / 2);
-        compoundBag.AddCompound(Compound.ByName("atp"), compoundBag.Capacity - OsmoregulationCost(organelles, membrane));
+        compoundBag.AddCompound(Compound.ByName("atp"), compoundBag.Capacity - totalCost);
 
-        var tweekedProcesses = SlicedProcesses(compoundBag, organelles, biome, OsmoregulationCost(organelles, membrane));
+        var tweekedProcesses = SlicedProcesses(compoundBag, organelles, biome, totalCost);
 
         foreach (var process in tweekedProcesses)
         {
@@ -422,9 +423,9 @@ public static class MicrobeInternalCalculations
     }
 
     public static Dictionary<Compound, CompoundBalance> ComputeCompoundBalance(
-        IEnumerable<OrganelleTemplate> organelles, MembraneType membrane, BiomeConditions biome)
+        IEnumerable<OrganelleTemplate> organelles, MembraneType membrane, BiomeConditions biome, bool moving)
     {
-        return ComputeCompoundBalance(organelles.Select(o => o.Definition), membrane, biome);
+        return ComputeCompoundBalance(organelles.Select(o => o.Definition), membrane, biome, moving);
     }
 
     public static IEnumerable<TweakedProcess> SlicedProcesses(CompoundBag compoundBag, IEnumerable<OrganelleDefinition> organelles, BiomeConditions biome, float totalCost)

--- a/src/microbe_stage/OrganelleDefinition.cs
+++ b/src/microbe_stage/OrganelleDefinition.cs
@@ -437,6 +437,16 @@ public class OrganelleDefinition : IRegistryType
         return Name + " Organelle";
     }
 
+    public float Storage()
+    {
+        if (Components.Storage != null)
+        {
+            return ((StorageComponentFactory)Components.Storage).Capacity;
+        }
+
+        return 0.0f;
+    }
+
     private void ComputeFactoryCache()
     {
         HasPilusComponent = HasComponentFactory<PilusComponentFactory>();

--- a/src/microbe_stage/ProcessPanel.cs
+++ b/src/microbe_stage/ProcessPanel.cs
@@ -64,7 +64,7 @@ public class ProcessPanel : CustomDialog
                 "Using " + movementCostDisplay + " ATP for movement\n" +
                 "Total: " + (osmoregulationCostDisplay + movementCostDisplay);
 
-            var temp = MicrobeInternalCalculations.SlicedProcesses(Microbe, Biome, totalCost);
+            var temp = MicrobeInternalCalculations.SlicedProcesses(Microbe.Compounds, Microbe.organelles.Select(x => x.Definition), Biome, totalCost);
 
             // Update the list object
             processList.ProcessesToShow = temp.Select(x => (IProcessDisplayInfo) new StaticProcessDisplayInfo(x.Process.Name, x)).ToList();

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -351,10 +351,10 @@ public partial class CellEditorComponent
         }
     }
 
-    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
+    private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balancesStationary, Dictionary<Compound, CompoundBalance> balancesMoving)
     {
-        compoundBalanceStationary.UpdateBalances(balances, true);
-        compoundBalanceMoving.UpdateBalances(balances, false);
+        compoundBalanceStationary.UpdateBalances(balancesStationary, true);
+        compoundBalanceMoving.UpdateBalances(balancesMoving, false);
     }
 
     private void UpdateEnergyBalance(EnergyBalanceInfo energyBalance)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -353,8 +353,8 @@ public partial class CellEditorComponent
 
     private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balancesStationary, Dictionary<Compound, CompoundBalance> balancesMoving)
     {
-        compoundBalanceStationary.UpdateBalances(balancesStationary, true);
-        compoundBalanceMoving.UpdateBalances(balancesMoving, false);
+        compoundBalanceStationary.UpdateBalances(balancesStationary, false);
+        compoundBalanceMoving.UpdateBalances(balancesMoving, true);
     }
 
     private void UpdateEnergyBalance(EnergyBalanceInfo energyBalance)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -353,7 +353,8 @@ public partial class CellEditorComponent
 
     private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
     {
-        compoundBalance.UpdateBalances(balances);
+        compoundBalanceStationary.UpdateBalances(balances);
+        compoundBalanceMoving.UpdateBalances(balances);
     }
 
     private void UpdateEnergyBalance(EnergyBalanceInfo energyBalance)

--- a/src/microbe_stage/editor/CellEditorComponent.GUI.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.GUI.cs
@@ -353,8 +353,8 @@ public partial class CellEditorComponent
 
     private void UpdateCompoundBalances(Dictionary<Compound, CompoundBalance> balances)
     {
-        compoundBalanceStationary.UpdateBalances(balances);
-        compoundBalanceMoving.UpdateBalances(balances);
+        compoundBalanceStationary.UpdateBalances(balances, true);
+        compoundBalanceMoving.UpdateBalances(balances, false);
     }
 
     private void UpdateEnergyBalance(EnergyBalanceInfo energyBalance)

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -1389,9 +1389,10 @@ public partial class CellEditorComponent :
     {
         patch ??= Editor.CurrentPatch;
 
-        var result = MicrobeInternalCalculations.ComputeCompoundBalance(organelles, membrane, patch.Biome);
+        var stationary = MicrobeInternalCalculations.ComputeCompoundBalance(organelles, membrane, patch.Biome, false);
+        var moving = MicrobeInternalCalculations.ComputeCompoundBalance(organelles, membrane, patch.Biome, true);
 
-        UpdateCompoundBalances(result);
+        UpdateCompoundBalances(stationary, moving);
     }
 
     /// <summary>

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -829,7 +829,7 @@ public partial class CellEditorComponent :
         CalculateEnergyBalanceWithOrganellesAndMembraneType(
             editedMicrobeOrganelles.Organelles, Membrane, Editor.CurrentPatch);
 
-        CalculateCompoundBalanceInPatch(editedMicrobeOrganelles.Organelles, Editor.CurrentPatch);
+        CalculateCompoundBalanceInPatch(editedMicrobeOrganelles.Organelles, Membrane, Editor.CurrentPatch);
     }
 
     /// <summary>
@@ -1385,11 +1385,11 @@ public partial class CellEditorComponent :
             Editor.CurrentGame.WorldSettings, true));
     }
 
-    private void CalculateCompoundBalanceInPatch(IReadOnlyCollection<OrganelleTemplate> organelles, Patch? patch = null)
+    private void CalculateCompoundBalanceInPatch(IReadOnlyCollection<OrganelleTemplate> organelles, MembraneType membrane, Patch? patch = null)
     {
         patch ??= Editor.CurrentPatch;
 
-        var result = MicrobeInternalCalculations.ComputeCompoundBalance(organelles, patch.Biome);
+        var result = MicrobeInternalCalculations.ComputeCompoundBalance(organelles, membrane, patch.Biome);
 
         UpdateCompoundBalances(result);
     }

--- a/src/microbe_stage/editor/CellEditorComponent.cs
+++ b/src/microbe_stage/editor/CellEditorComponent.cs
@@ -123,7 +123,10 @@ public partial class CellEditorComponent :
     public NodePath OrganelleMenuPath = null!;
 
     [Export]
-    public NodePath CompoundBalancePath = null!;
+    public NodePath CompoundBalancePathStationary = null!;
+
+    [Export]
+    public NodePath CompoundBalancePathMoving = null!;
 
     [Export]
     public NodePath AutoEvoPredictionExplanationPopupPath = null!;
@@ -183,7 +186,8 @@ public partial class CellEditorComponent :
     private OrganellePopupMenu organelleMenu = null!;
     private OrganelleUpgradeGUI organelleUpgradeGUI = null!;
 
-    private CompoundBalanceDisplay compoundBalance = null!;
+    private CompoundBalanceDisplay compoundBalanceStationary = null!;
+    private CompoundBalanceDisplay compoundBalanceMoving = null!;
 
     private CustomDialog autoEvoPredictionExplanationPopup = null!;
     private Label autoEvoPredictionExplanationLabel = null!;
@@ -599,7 +603,8 @@ public partial class CellEditorComponent :
         organelleMenu = GetNode<OrganellePopupMenu>(OrganelleMenuPath);
         organelleUpgradeGUI = GetNode<OrganelleUpgradeGUI>(OrganelleUpgradeGUIPath);
 
-        compoundBalance = GetNode<CompoundBalanceDisplay>(CompoundBalancePath);
+        compoundBalanceStationary = GetNode<CompoundBalanceDisplay>(CompoundBalancePathStationary);
+        compoundBalanceMoving = GetNode<CompoundBalanceDisplay>(CompoundBalancePathMoving);
 
         autoEvoPredictionExplanationPopup = GetNode<CustomDialog>(AutoEvoPredictionExplanationPopupPath);
         autoEvoPredictionExplanationLabel = GetNode<Label>(AutoEvoPredictionExplanationLabelPath);

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -1009,7 +1009,7 @@ margin_bottom = 275.0
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 254.0
-margin_right = 246.0
+margin_right = 146.0
 margin_bottom = 275.0
 
 [node name="AutoEvoInfoPanel" type="PanelContainer" parent="RightPanel/VBoxContainer"]

--- a/src/microbe_stage/editor/CellEditorComponent.tscn
+++ b/src/microbe_stage/editor/CellEditorComponent.tscn
@@ -250,7 +250,8 @@ RigiditySliderPath = NodePath("LeftPanel/MainPanel/VBoxContainer/MarginContainer
 NegativeAtpPopupPath = NodePath("NegativeAtpWarning")
 NoMovementPopupPath = NodePath("NoMovementWarning")
 OrganelleMenuPath = NodePath("OrganellePopupMenu")
-CompoundBalancePath = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/CompoundBalanceDisplay")
+CompoundBalancePathStationary = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/CompoundBalanceDisplayStationary")
+CompoundBalancePathMoving = NodePath("RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer/CompoundBalanceDisplayMoving")
 AutoEvoPredictionExplanationPopupPath = NodePath("PredictionExplanation")
 AutoEvoPredictionExplanationLabelPath = NodePath("PredictionExplanation/VBoxContainer/ScrollContainer/MarginContainer/VBoxContainer/ExplanationText")
 OrganelleUpgradeGUIPath = NodePath("OrganelleUpgradeGUI")
@@ -997,7 +998,14 @@ rect_min_size = Vector2( 0, 10 )
 mouse_filter = 1
 custom_styles/separator = SubResource( 20 )
 
-[node name="CompoundBalanceDisplay" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource( 42 )]
+[node name="CompoundBalanceDisplayStationary" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource( 42 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 254.0
+margin_right = 246.0
+margin_bottom = 275.0
+
+[node name="CompoundBalanceDisplayMoving" parent="RightPanel/VBoxContainer/Statistics/VBoxContainer/Body/ScrollContainer/MarginContainer/VBoxContainer" instance=ExtResource( 42 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 254.0

--- a/src/microbe_stage/editor/CompoundBalanceDisplay.cs
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.cs
@@ -42,6 +42,10 @@ public class CompoundBalanceDisplay : VBoxContainer
 
         foreach (var entry in balances)
         {
+            if (entry.Key.IsEnvironmental)
+            {
+                continue;
+            }
             var compoundControl = childCache.GetChild(entry.Key);
             var amount = entry.Value.Production.SumValues() > 0.0f ?
                 entry.Value.Production.SumValues() - entry.Value.Consumption.SumValues() / 2.0f

--- a/src/microbe_stage/editor/CompoundBalanceDisplay.cs
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.cs
@@ -9,20 +9,35 @@ public class CompoundBalanceDisplay : VBoxContainer
     [Export]
     public NodePath CompoundListContainerPath = null!;
 
+    [Export]
+    public NodePath LabelPath = null!;
+
     private VBoxContainer compoundListContainer = null!;
+
+    private Label label = null!;
 
     private ChildObjectCache<Compound, CompoundAmount> childCache = null!;
 
     public override void _Ready()
     {
         compoundListContainer = GetNode<VBoxContainer>(CompoundListContainerPath);
+        label = GetNode<Label>(LabelPath);
 
         childCache = new ChildObjectCache<Compound, CompoundAmount>(compoundListContainer,
             compound => new CompoundAmount { Compound = compound, PrefixPositiveWithPlus = true });
     }
 
-    public void UpdateBalances(Dictionary<Compound, CompoundBalance> balances)
+    public void UpdateBalances(Dictionary<Compound, CompoundBalance> balances, bool moving)
     {
+        if (moving)
+        {
+            label.Text = new LocalizedString("COMPOUND_BALANCE_TITLE") + " (Moving)";
+        }
+        else
+        {
+            label.Text = new LocalizedString("COMPOUND_BALANCE_TITLE") + " (Stationary)";
+        }
+
         childCache.UnMarkAll();
 
         foreach (var entry in balances)

--- a/src/microbe_stage/editor/CompoundBalanceDisplay.tscn
+++ b/src/microbe_stage/editor/CompoundBalanceDisplay.tscn
@@ -14,13 +14,17 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 CompoundListContainerPath = NodePath("VBoxContainer")
+LabelPath = NodePath("DifferentName")
 
-[node name="Label" type="Label" parent="."]
+
+[node name="DifferentName" type="Label" parent="."]
 margin_right = 1280.0
 margin_bottom = 17.0
 custom_fonts/font = ExtResource( 2 )
 text = "COMPOUND_BALANCE_TITLE"
 autowrap = true
+
+
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_top = 21.0


### PR DESCRIPTION
**Brief Description of What This PR Does**

Makes the editor show estimates of compound rates both when moving and not moving, to make it easier to figure out when a sessile build is feasible. Then there's a ton of refactors to support that.

**Related Issues (if any)**


