### PR TITLE
Don't save Miche property of Patch

### DIFF
--- a/src/microbe_stage/Patch.cs
+++ b/src/microbe_stage/Patch.cs
@@ -68,6 +68,7 @@ public class Patch
     [JsonIgnore]
     public Dictionary<Species, long> SpeciesInPatch => currentSnapshot.SpeciesInPatch;
 
+    [JsonIgnore]
     public Miche Miche = Miche.RootMiche();
 
     [JsonIgnore]


### PR DESCRIPTION
**Brief Description of What This PR Does**

Having it as a JSON property breaks saving for whatever reason, but it seems like things are fine if you just don't add them to the JSON.

**Related Issues (if any)**


