### PR TITLE
Rebalance Spawners

### DIFF
--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -478,7 +478,7 @@ public static class Constants
     /// <summary>
     ///   Maximum extra microbes to spawn
     /// </summary>
-    public const int MAX_BACTERIAL_COLONY_SIZE = 1;
+    public const int MAX_BACTERIAL_COLONY_SIZE = 3;
 
     // What is divided during fear and aggression calculations in the AI
     public const float AGGRESSION_DIVISOR = 25.0f;

--- a/simulation_parameters/Constants.cs
+++ b/simulation_parameters/Constants.cs
@@ -22,7 +22,7 @@ public static class Constants
     /// <summary>
     ///   Size of "chunks" used for spawning entities
     /// </summary>
-    public const float SPAWN_SECTOR_SIZE = 120.0f;
+    public const float SPAWN_SECTOR_SIZE = 100.0f;
 
     public const int CLOUD_SPAWN_SCALE_FACTOR = 10000;
 

--- a/src/microbe_stage/MicrobeCamera.cs
+++ b/src/microbe_stage/MicrobeCamera.cs
@@ -46,7 +46,7 @@ public class MicrobeCamera : Camera, IGodotEarlyNodeResolve, ISaveLoadedTracked
     /// </summary>
     [Export]
     [JsonProperty]
-    public float MaxCameraHeight = 80.0f;
+    public float MaxCameraHeight = 60.0f;
 
     [Export]
     [JsonProperty]

--- a/src/microbe_stage/PatchManager.cs
+++ b/src/microbe_stage/PatchManager.cs
@@ -186,7 +186,7 @@ public class PatchManager : IChildPropertiesLoadCallback
                 continue;
             }
 
-            var density = Mathf.Max(Mathf.Log(species.Population / 50.0f) * 0.01f, 0.0f);
+            var density = Mathf.Max(Mathf.Log(species.Population / 10.0f) * 0.01f, 0.0f);
 
             var name = species.ID.ToString(CultureInfo.InvariantCulture);
 


### PR DESCRIPTION
**Brief Description of What This PR Does**

Make microbes, particularly sessile microbes, show up more often. Necessitates dropping the view distance, but that was probably for the best anyway.

**Related Issues (if any)**


