### PR TITLE
Mp rework

### DIFF
--- a/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
+++ b/src/early_multicellular_stage/editor/EarlyMulticellularEditor.cs
@@ -115,7 +115,7 @@ public class EarlyMulticellularEditor : EditorBase<EditorAction, MicrobeStage>, 
 
     public override int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
     {
-        return history.WhatWouldActionsCost(actions);
+        return CheatManager.InfiniteMP ? 0 : history.WhatWouldActionsCost(actions);
     }
 
     public override bool EnqueueAction(EditorAction action)

--- a/src/general/EditorBase.cs
+++ b/src/general/EditorBase.cs
@@ -852,7 +852,7 @@ public abstract class EditorBase<TAction, TStage> : NodeWithInput, IEditor, ILoa
 
         mutationPointsCache = history.CalculateMutationPointsLeft();
 
-        if (mutationPointsCache.Value < 0 || mutationPointsCache > EditorGlobals.MaxMutationPoints)
+        if (mutationPointsCache.Value < 0)
         {
             GD.PrintErr("Invalid MP amount: ", mutationPointsCache,
                 " This should only happen if the user disabled the Infinite MP cheat while having mutated too much.");

--- a/src/microbe_stage/MicrobeStage.cs
+++ b/src/microbe_stage/MicrobeStage.cs
@@ -756,9 +756,8 @@ public class MicrobeStage : NodeWithInput, IReturnableGameState, IGodotEarlyNode
         if (CurrentGame == null)
             throw new InvalidOperationException("Returning to stage from editor without a game setup");
 
-        EditorGlobals.MaxMutationPoints = Constants.BASE_MUTATION_POINTS - random.Next(50);
+        EditorGlobals.MaxMutationPoints = Constants.BASE_MUTATION_POINTS - random.Next(30) - random.Next(30);
         savedMaxMutationPoints = EditorGlobals.MaxMutationPoints;
-        GD.Print("setting saved max to " + savedMaxMutationPoints);
         if (PityPopulation != null)
         {
             GameWorld.PlayerSpecies.Population = (long)PityPopulation;

--- a/src/microbe_stage/editor/MicrobeEditor.cs
+++ b/src/microbe_stage/editor/MicrobeEditor.cs
@@ -106,7 +106,7 @@ public class MicrobeEditor : EditorBase<EditorAction, MicrobeStage>, IEditorRepo
 
     public override int WhatWouldActionsCost(IEnumerable<EditorCombinableActionData> actions)
     {
-        return history.WhatWouldActionsCost(actions);
+        return CheatManager.InfiniteMP ? 0 : history.WhatWouldActionsCost(actions);
     }
 
     protected override void ResolveDerivedTypeNodeReferences()


### PR DESCRIPTION
**Brief Description of What This PR Does**

Slightly lowers the amount of MP gained in each generation, and tweaks the infinite MP cheat to always be able to afford anything.

**Related Issues (if any)**


