### PR TITLE
don't try to add mutants in pull step unless nothign else worked

### DIFF
--- a/src/auto-evo/steps/PullSpeciesForPatch.cs
+++ b/src/auto-evo/steps/PullSpeciesForPatch.cs
@@ -98,7 +98,10 @@ class PullSpeciesForPatch : IRunStep
         }
 
         // If no existing species can do the job, make a new one
-        retval.AddRange(FillEmptyMiches(foreignSpecies, results, patch, cache));
+        if (retval.Count() == 0)
+        {
+            retval.AddRange(FillEmptyMiches(foreignSpecies, results, patch, cache));
+        }
 
         return retval;
     }


### PR DESCRIPTION
**Brief Description of What This PR Does**

The pull step will now skip mutations if any other pull attempt worked. This saves some computations and doesn't seem to change results much.

**Related Issues (if any)**


