### PR TITLE
don't allow species that can't move or make energy

### DIFF
--- a/src/auto-evo/simulation/selection_pressure/MetabolicStabilityPressure.cs
+++ b/src/auto-evo/simulation/selection_pressure/MetabolicStabilityPressure.cs
@@ -7,6 +7,8 @@ class MetabolicStabilityPressure : SelectionPressure
 {
     private Patch Patch;
 
+    private AutotrophEnergyEfficiencyPressure SunPressure;
+
     public MetabolicStabilityPressure(Patch patch, float weight) : base(true,
         weight,
         new List<IMutationStrategy<MicrobeSpecies>>
@@ -17,6 +19,7 @@ class MetabolicStabilityPressure : SelectionPressure
         )
     {
         Patch = patch;
+        SunPressure = new AutotrophEnergyEfficiencyPressure(patch, Compound.ByName("sunlight"), 1.0f);
     }
 
     public override string Name()
@@ -28,6 +31,12 @@ class MetabolicStabilityPressure : SelectionPressure
     {
         if (species is MicrobeSpecies)
         {
+            if (((MicrobeSpecies)species).BaseSpeed == 0
+                && SunPressure.Score(species, cache) < 0.1f)
+            {
+                return 0.0f;
+            }
+
             return ScoreByCell((MicrobeSpecies)species, cache);
         }
         else


### PR DESCRIPTION
**Brief Description of What This PR Does**

The metabolic stability pressure wasn't accounting for getting the compound being used to MAKE atp. As a stopgap, this just checks species that can't move, since we know that these can only be photosynthesizers.

**Related Issues (if any)**


