### PR TITLE
hacky fix to make game not crash at startup

### DIFF
--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@
 // NOTE: the version info is read by a regex in a script so don't add complicated things to this file
 // NOTE: When changing the version number you need to also change "export_presets.cfg"
 
-[assembly: AssemblyVersion("0.5.9.1")]
+[assembly: AssemblyVersion("0.6.1.0")]
 
 [assembly: AssemblyInformationalVersion("-thim")]
 

--- a/src/engine/input/key_mapping/SpecifiedInputKey.cs
+++ b/src/engine/input/key_mapping/SpecifiedInputKey.cs
@@ -86,7 +86,7 @@ public class SpecifiedInputKey : ICloneable
         {
             InputType.Key => new InputEventKey { Scancode = Code },
             InputType.MouseButton => new InputEventMouseButton { ButtonIndex = (int)Code },
-            _ => throw new NotSupportedException("Unsupported InputType given"),
+            _ => new InputEventKey { Scancode = Code},
         };
 
         result.Alt = Alt;


### PR DESCRIPTION
**Brief Description of What This PR Does**

Looks like something with the settings files of new mainline versions of Thrive make the executable not startup any more. A more long-term solution would be to find a way to divorce those settings files.

**Related Issues (if any)**


